### PR TITLE
SECURITY / XSS : Stop XSS in post subjects displayed in catalog

### DIFF
--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -52,14 +52,22 @@
 						{% else %}
 							<img src="{{post.file}}" 
 						{% endif %}
-                                                 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject }}{% endif %}" data-name="{{ post.name }}" data-muhdifference="{{ post.muhdifference }}" data-last-reply="{% if post.last_reply %}{{ post.last_reply }}{% endif %}" data-last-subject="{% if post.last_reply_subject %}{{ post.last_reply_subject }}{% endif %}" data-last-name="{% if post.last_reply %}{{ post.last_reply_name }}{% endif %}" data-last-difference="{% if post.last_reply %}{{ post.last_reply_difference }}{% endif %}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
+                                                 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
                                         </a>
-                                        <p>
-                                                <span class="replies">
-                                                        <strong>R: {{ post.reply_count }} / I: {{ post.image_count }}</strong><br/>
-                                                        {{ post.body }}
-                                                </span>
-                                        </p>
+                                                <div class="replies">
+                                                        <strong>R: {{ post.reply_count }} / I: {{ post.image_count }}</strong>
+                                                        {% if post.subject %}
+								<p class="intro">
+									<span class="subject">
+										{{ post.subject|e }}
+									</span>
+								</p>
+							{% else %}
+								<br />
+							{% endif %}
+
+								{{ post.body }}
+                                                </div>
                                 </div>
                         </li>
                 {% endfor %}


### PR DESCRIPTION
git blame says czaks forgot an |e in catalog.html, this means that anyone posting a new thread with HTML in the subject field or name field can arbitrarily insert it into the page.

Conflicts:
	templates/themes/catalog/catalog.html